### PR TITLE
#149469113 -Adding functionality for managers to deactivate and delete trainers from a gym

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -35,10 +35,11 @@
 {% for current_user in object_list.admins %}
 <tr>
     <td>
+        
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}"> {{current_user.obj}}</a>
 
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>
@@ -53,6 +54,7 @@
         {% endif %}
     </td>
     <td>
+        
         {{current_user.obj.get_full_name}}
     </td>
 

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -39,8 +39,11 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}"> {{current_user.obj}}</a>
-
+        {% if current_user.perms.manage_gym or current_user.perms.manage_gyms%}
+         {{current_user.obj}}
+        {% else %}
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        {% endif %}
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>
         {% endif %}

--- a/wger/utils/language.py
+++ b/wger/utils/language.py
@@ -49,7 +49,7 @@ def load_language(language_code=None):
         return language
 
     try:
-        language = Language.objects.get(short_name=used_language)
+        language = Language.objects.get_or_create(short_name=used_language)
     except ObjectDoesNotExist:
         # No luck, load english as our fall-back language
         language = Language.objects.get(short_name="en")

--- a/wger/utils/language.py
+++ b/wger/utils/language.py
@@ -49,7 +49,7 @@ def load_language(language_code=None):
         return language
 
     try:
-        language = Language.objects.get_or_create(short_name=used_language)
+        language = Language.objects.get(short_name=used_language)
     except ObjectDoesNotExist:
         # No luck, load english as our fall-back language
         language = Language.objects.get(short_name="en")


### PR DESCRIPTION
**What does this PR do?**
Adds functionality for an administrator to deactivate or delete a gym trainer on the gym view
**Description of Task to be completed?**
Previously a manager could not delete or deactivate trainers from a gym. This PR adds the required functionality to do this
**How should this be manually tested?**
When logged in as a manager, on the **_view gym page_**, click the username of the trainer of interest and on the displayed page, click the _**action**_ button to delete or deactivate