### PR TITLE
#Chore Make Travis CI build jobs run parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,4 @@ node_modules
 
 # Others
 .DS_Store
-.circleci/
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,14 @@ env:
 
 matrix:
     env:
-      - TESTFOLDER=wger/config/tests
-      - TESTFOLDER=wger/core/tests
-      - TESTFOLDER=wger/email/tests
-      - TESTFOLDER=wger/gym/tests
-      - TESTFOLDER=wger/manager/tests
-      - TESTFOLDER=wger/nutrition/tests
-      - TESTFOLDER=wger/utils/tests
-      - TESTFOLDER=wger/weight/tests
+      - TESTFOLDER=wger/config
+      - TESTFOLDER=wger/core
+      - TESTFOLDER=wger/email
+      - TESTFOLDER=wger/gym
+      - TESTFOLDER=wger/manager
+      - TESTFOLDER=wger/nutrition
+      - TESTFOLDER=wger/utils
+      - TESTFOLDER=wger/weight
 
 # Install the application
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ notifications:
     slack: andela:4Fln2jKzeoQJkyrxKPheRPOC
 
 # Python versions to test
-python: $python_version
+python: $$python_version
 
 # Manually define here the combinations environment variables to test
 # https://github.com/travis-ci/travis-ci/issues/1519

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,16 @@ env:
   - TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
   - TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
 
-  - TESTFOLDER=wger/config/tests
-  - TESTFOLDER=wger/core/tests
-  - TESTFOLDER=wger/email/tests
-  - TESTFOLDER=wger/gym/tests
-  - TESTFOLDER=wger/manager/tests
-  - TESTFOLDER=wger/nutrition/tests
-  - TESTFOLDER=wger/utils/tests
-  - TESTFOLDER=wger/weight/tests
+matrix:
+    env:
+      - TESTFOLDER=wger/config/tests
+      - TESTFOLDER=wger/core/tests
+      - TESTFOLDER=wger/email/tests
+      - TESTFOLDER=wger/gym/tests
+      - TESTFOLDER=wger/manager/tests
+      - TESTFOLDER=wger/nutrition/tests
+      - TESTFOLDER=wger/utils/tests
+      - TESTFOLDER=wger/weight/tests
 
 # Install the application
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
   - TESTFOLDER=wger/gym TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/manager TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/nutrition TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/utils TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/utils TEST_MOBILE=False  DB=postgresql TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/weight TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - TESTFOLDER=wger/config TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/core TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/email TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/exercises TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/gym TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/manager TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
   - TESTFOLDER=wger/nutrition TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,15 @@ python:
 # Manually define here the combinations environment variables to test
 # https://github.com/travis-ci/travis-ci/issues/1519
 env:
-  - TESTFOLDER=extras/bench TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/config TEST_MOBILE=True  DB=sqlite TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/core TEST_MOBILE=False  DB=postgresql     TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/email TEST_MOBILE=False DB=sqlite TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/exercises TEST_MOBILE=True DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/gym TEST_MOBILE=True DB=sqlite     TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/manager TEST_MOBILE=False  DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/nutrition TEST_MOBILE=False  DB=sqlite     TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/utils TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/weight TEST_MOBILE=True DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/config TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/core TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/email TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/exercises TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/gym TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/manager TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/nutrition TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/utils TEST_MOBILE=False  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/weight TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
 
 
 # Install the application

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ notifications:
     slack: andela:4Fln2jKzeoQJkyrxKPheRPOC
 
 # Python versions to test
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
+python: $python_version
 
 # Manually define here the combinations environment variables to test
 # https://github.com/travis-ci/travis-ci/issues/1519
@@ -76,6 +73,12 @@ script:
 
   # Code coverage
   - coverage report
+
+matrix:
+  python_version:
+    - 2.7
+    - 3.4
+    - 3.5
 
 after_script:
     coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ script:
   # Regular application
   - coverage run --source='.' ./manage.py test $TESTFOLDER
 
-
   # Code coverage
   - coverage report
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,16 @@ python:
 # Manually define here the combinations environment variables to test
 # https://github.com/travis-ci/travis-ci/issues/1519
 env:
-  - TESTFOLDER=wger/config TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/core TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/email TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/exercises TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/gym TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/manager TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/nutrition TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/utils TEST_MOBILE=False  DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TESTFOLDER=wger/weight TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=extras/bench TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/config TEST_MOBILE=True  DB=sqlite TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/core TEST_MOBILE=False  DB=postgresql     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/email TEST_MOBILE=False DB=sqlite TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/exercises TEST_MOBILE=True DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/gym TEST_MOBILE=True DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/manager TEST_MOBILE=False  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/nutrition TEST_MOBILE=False  DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/utils TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/weight TEST_MOBILE=True DB=sqlite     TRAVIS_NODE_VERSION="4"
 
 
 # Install the application

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,15 @@ python:
 # Manually define here the combinations environment variables to test
 # https://github.com/travis-ci/travis-ci/issues/1519
 env:
-  - TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
-  - TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
-  - TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/config TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/core TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/email TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/gym TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/manager TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/nutrition TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/utils TEST_MOBILE=True  DB=postgresql TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/weight TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
 
-matrix:
-    env:
-      - TESTFOLDER=wger/config
-      - TESTFOLDER=wger/core
-      - TESTFOLDER=wger/email
-      - TESTFOLDER=wger/gym
-      - TESTFOLDER=wger/manager
-      - TESTFOLDER=wger/nutrition
-      - TESTFOLDER=wger/utils
-      - TESTFOLDER=wger/weight
 
 # Install the application
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,14 @@ env:
   - TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
   - TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
   - TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
+  - TESTFOLDER=wger/config/tests
+  - TESTFOLDER=wger/core/tests
+  - TESTFOLDER=wger/email/tests
+  - TESTFOLDER=wger/gym/tests
+  - TESTFOLDER=wger/manager/tests
+  - TESTFOLDER=wger/nutrition/tests
+  - TESTFOLDER=wger/utils/tests
+  - TESTFOLDER=wger/weight/tests
 
 # Install the application
 install:
@@ -67,7 +75,7 @@ script:
   - gulp lint
 
   # Regular application
-  - coverage run --source='.' ./manage.py test
+  - coverage run --source='.' ./manage.py test $TESTFOLDER
 
 
   # Code coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   - TEST_MOBILE=True  DB=sqlite     TRAVIS_NODE_VERSION="4"
   - TEST_MOBILE=False DB=postgresql TRAVIS_NODE_VERSION="4"
   - TEST_MOBILE=False DB=sqlite     TRAVIS_NODE_VERSION="4"
+
   - TESTFOLDER=wger/config/tests
   - TESTFOLDER=wger/core/tests
   - TESTFOLDER=wger/email/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ notifications:
     slack: andela:4Fln2jKzeoQJkyrxKPheRPOC
 
 # Python versions to test
-python: $$python_version
+python:
+    - 2.7
+    - 3.4
+    - 3.5
 
 # Manually define here the combinations environment variables to test
 # https://github.com/travis-ci/travis-ci/issues/1519
@@ -73,12 +76,6 @@ script:
 
   # Code coverage
   - coverage report
-
-matrix:
-  python_version:
-    - 2.7
-    - 3.4
-    - 3.5
 
 after_script:
     coveralls


### PR DESCRIPTION
#### What does this PR do?
Travis CI now runs wger's tests in separate broken down folders. [Core, Email, Gym, Nutrition] etc.
Each of these test suites runs parallel to the others, and thus saves time taken by the entire build.

#### Challenges
The default number of concurrent jobs for any build in Travis is 5. Since breaking the test suite into 7 different folders has now created around 24 jobs that need to run, the entire build is still taking too long to complete

#### How can this be tested manually?
Trigger a CI build by pushing changes on any branch, and watch how each of the 24 jobs runs, and how much time they take.
Builds now take an average of 23 minutes to complete, as opposed to >100 minutes earlier. 